### PR TITLE
Fix iframe sizing on Updates page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - '2.7'
 
 env:
-  - AWS_SECRET_ACCESS_KEY=abc DJANGO_SECRET_KEY=abc
+  - AWS_SECRET_ACCESS_KEY=abc DJANGO_SECRET_KEY=abc BOTO_CONFIG=/tmp
 
 before_install:
   - sudo mkdir /var/log/django

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_install:
 
 install: pip install -r requirements.txt
 
-script: python manage.py test
+script: python manage.py test --settings=gitensite.travis_settings

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
 
 before_install:
   - sudo mkdir /var/log/django
+  - sudo chmod 777 /var/log/django
 
 install: pip install -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ python:
   - '2.7'
 
 env:
-  - AWS_SECRET_ACCESS_KEY=abc
-  - DJANGO_SECRET_KEY=abc
+  - AWS_SECRET_ACCESS_KEY=abc DJANGO_SECRET_KEY=abc
 
 install: pip install -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: python
 python:
   - '2.7'
 
+env:
+  - AWS_SECRET_ACCESS_KEY=abc
+  - DJANGO_SECRET_KEY=abc
+
 install: pip install -r requirements.txt
 
 script: python manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+
+python:
+  - '2.7'
+
+install: pip install -r requirements.txt
+
+script: python manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
 env:
   - AWS_SECRET_ACCESS_KEY=abc DJANGO_SECRET_KEY=abc
 
+before_install:
+  - mkdir /var/log/django
+
 install: pip install -r requirements.txt
 
 script: python manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - AWS_SECRET_ACCESS_KEY=abc DJANGO_SECRET_KEY=abc
 
 before_install:
-  - mkdir /var/log/django
+  - sudo mkdir /var/log/django
 
 install: pip install -r requirements.txt
 

--- a/gitensite/apps/content/templates/updates.html
+++ b/gitensite/apps/content/templates/updates.html
@@ -6,7 +6,9 @@
 <script language="javascript" type="text/javascript">
     //Automatically set the height of the iframe based on the height of its contents
     function resizeIframe(obj){
-        obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px';
+        window.setTimeout(function(){
+            obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px';
+        }, 500);
     }
 </script>
 
@@ -14,6 +16,7 @@
     iframe {
         width: 100%;
         border: 0;
+        height: 2000px; /* initial height - will be overridden by resizeIframe function */
     }
 </style>
 

--- a/gitensite/travis_settings.py
+++ b/gitensite/travis_settings.py
@@ -1,0 +1,4 @@
+from gitensite.settings import *
+
+SESSION_COOKIE_SECURE = False
+SECURE_SSL_REDIRECT = False

--- a/gitensite/travis_settings.py
+++ b/gitensite/travis_settings.py
@@ -1,4 +1,223 @@
-from gitensite.settings import *
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Django settings for gitensite project.
 
-SESSION_COOKIE_SECURE = False
-SECURE_SSL_REDIRECT = False
+For more information on this file, see
+https://docs.djangoproject.com/en/1.7/topics/settings/
+
+For the full list of settings and their values, see
+https://docs.djangoproject.com/en/1.7/ref/settings/
+"""
+import os
+from django.conf.global_settings import TEMPLATE_CONTEXT_PROCESSORS
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
+# use environment variable to set DJANGO_SECRET_KEY
+SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = bool(os.environ.get('DJANGO_DEBUG',False))
+TEMPLATE_DEBUG = DEBUG
+
+ALLOWED_HOSTS = []
+
+# Application definition
+COMMON_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+
+    'django_extensions',
+    'foundation',
+    'fontawesome',
+    'djcelery',
+    'storages',
+    'sorl.thumbnail',
+    'el_pagination',
+    'sh',
+    'gitenberg',
+]
+
+LOCAL_APPS = [
+    'gitensite.apps.content',
+    'gitensite.apps.bookrepos',
+    'gitensite.apps.bookinfo',
+]
+
+INSTALLED_APPS = COMMON_APPS + LOCAL_APPS
+
+MIDDLEWARE_CLASSES = [
+    'djangosecure.middleware.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+TEMPLATE_CONTEXT_PROCESSORS += (
+    'django.core.context_processors.request',
+)
+
+ROOT_URLCONF = 'gitensite.urls'
+
+WSGI_APPLICATION = 'gitensite.wsgi.application'
+
+# Database
+# https://docs.djangoproject.com/en/1.7/ref/settings/#databases
+if 'RDS_HOSTNAME' in os.environ:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': os.environ['RDS_DB_NAME'],
+            'USER': os.environ['RDS_USERNAME'],
+            'PASSWORD': os.environ['RDS_PASSWORD'],
+            'HOST': os.environ['RDS_HOSTNAME'],
+            'PORT': os.environ['RDS_PORT'],
+        }
+    }
+else:
+    DATABASES = {
+        'default': {
+                'ENGINE': 'django.db.backends.postgresql_psycopg2',
+                'NAME': 'gitensite',
+                'USER': 'postgres',
+                'PASSWORD': 'gitensite',
+                'HOST': 'localhost',
+                'PORT': '5432',
+        }
+    }
+
+# Internationalization
+# https://docs.djangoproject.com/en/1.8/topics/i18n/
+LANGUAGE_CODE = 'en-us'
+TIME_ZONE = 'UTC'
+USE_I18N = True
+USE_L10N = True
+USE_TZ = True
+
+# AWS S3
+# https://www.caktusgroup.com/blog/2014/11/10/Using-Amazon-S3-to-store-your-Django-sites-static-and-media-files/
+
+AWS_HEADERS = {  # see http://developer.yahoo.com/performance/rules.html#expires
+    'Expires': 'Thu, 31 Dec 2099 20:00:00 GMT',
+    'Cache-Control': 'max-age=94608000',
+}
+AWS_STORAGE_BUCKET_NAME = 'gitensite'
+AWS_ACCESS_KEY_ID = 'AKIAIDP7I26XHV4SCSLA'
+# use environment variable to set AWS_SECRET_ACCESS_KEY
+AWS_SECRET_ACCESS_KEY = os.environ['AWS_SECRET_ACCESS_KEY']
+
+# Tell django-storages that when coming up with the URL for an item in S3 storage, keep
+# it simple - just use this domain plus the path. (If this isn't set, things get complicated).
+# This controls how the `static` template tag from `staticfiles` gets expanded, if you're using it.
+# We also use it in the next setting.
+AWS_S3_CUSTOM_DOMAIN = '%s.s3.amazonaws.com' % AWS_STORAGE_BUCKET_NAME
+
+# This is used by the `static` template tag from `static`, if you're using that. Or if anything else
+# refers directly to STATIC_URL. So it's safest to always set it.
+STATIC_URL = "https://%s/" % AWS_S3_CUSTOM_DOMAIN
+
+# Tell the staticfiles app to use S3Boto storage when writing the collected static files (when
+# you run `collectstatic`).
+STATICFILES_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/1.8/howto/static-files/
+STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, "static")
+STATICFILES_DIRS = (
+    os.path.join(BASE_DIR, "assets"),
+    os.path.join(BASE_DIR, "upload"),
+)
+
+
+# The in-development settings and the default configuration.
+if 'ENVIRONMENT' in os.environ and os.environ['ENVIRONMENT'] == 'DEVELOPMENT':
+    DEBUG = True
+    TEMPLATE_DEBUG = DEBUG
+
+    ALLOWED_HOSTS = ['localhost']
+
+    INSTALLED_APPS = COMMON_APPS + LOCAL_APPS + [
+        'debug_toolbar',
+    ]
+else:
+    # django-secure
+    ALLOWED_HOSTS = ['gitenberg.org', 'www.gitenberg.org', 'localhost']
+
+    #SESSION_COOKIE_SECURE = True
+    #SECURE_SSL_REDIRECT = True
+    #SECURE_HSTS_SECONDS = 3600
+    # SECURE_HSTS_INCLUDE_SUBDOMAINS = False
+    # SECURE_FRAME_DENY = True
+    # SECURE_CONTENT_TYPE_NOSNIFF = False
+    # SECURE_BROWSER_XSS_FILTER = True
+    #SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '%(levelname)s %(asctime)s %(module)s %(message)s',
+        }
+    },
+    'handlers': {
+        'file': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.RotatingFileHandler',
+            # TODO: create and use a /var/log location
+            'filename':  os.environ['DJANGO_LOG'] if 'DJANGO_LOG' in os.environ else '/var/log/django/django.log',
+            'maxBytes': 1024*1024*10,  # 10MB
+            'backupCount': 5,
+        },
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose',
+        },
+        'mail_admins': {
+            'level': 'ERROR',
+            'class': 'django.utils.log.AdminEmailHandler',
+            'formatter': 'verbose',
+        }
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['file', 'console'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+        'django.request': {
+            'handlers': ['file', 'console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'gitensite': {
+            'handlers': ['file', 'console'],
+            'level': 'DEBUG',
+        }
+    },
+}
+MEDIA_URL = '/static/media/'
+
+MEDIA_ROOT = os.path.join(BASE_DIR, "upload/media")
+
+import logging
+from sorl.thumbnail.log import ThumbnailLogHandler
+
+handler = ThumbnailLogHandler()
+handler.setLevel(logging.ERROR)
+logging.getLogger('sorl.thumbnail').addHandler(handler)
+


### PR DESCRIPTION
The iframes on the updates page would sometimes be set to the wrong size if the content size changes after the `resizeIframe` function runs. To solve this problem, we added a delay before the iframe is resized. We also added an initial height for the iframes, so that the user does not see the default size during the delay.