### PR TITLE
Fix iframe sizing on Updates page

### DIFF
--- a/gitensite/apps/content/templates/updates.html
+++ b/gitensite/apps/content/templates/updates.html
@@ -6,7 +6,9 @@
 <script language="javascript" type="text/javascript">
     //Automatically set the height of the iframe based on the height of its contents
     function resizeIframe(obj){
-        obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px';
+        window.setTimeout(function(){
+            obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px';
+        }, 500);
     }
 </script>
 
@@ -14,6 +16,7 @@
     iframe {
         width: 100%;
         border: 0;
+        height: 2000px; /* initial height - will be overridden by resizeIframe function */
     }
 </style>
 


### PR DESCRIPTION
The iframes on the updates page would sometimes be set to the wrong size if the content size changes after the `resizeIframe` function runs. To solve this problem, we added a delay before the iframe is resized. We also added an initial height for the iframes, so that the user does not see the default size during the delay.