### PR TITLE
changed print statements to make them compatible with python 3

### DIFF
--- a/gitensite/apps/bookinfo/management/commands/load_repos.py
+++ b/gitensite/apps/bookinfo/management/commands/load_repos.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -*- coding: utf-8 -*-
 import csv
 import requests

--- a/gitensite/apps/bookinfo/management/commands/load_repos.py
+++ b/gitensite/apps/bookinfo/management/commands/load_repos.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
                 book.yaml = metadata.__unicode__()
                 book.save()
             except (ValueError,IndexError):
-                print "!! {}".format(reponame)
+                print ("!! {}".format(reponame))
                 continue
-        print "{} books created".format(Book.objects.count())
+        print ("{} books created".format(Book.objects.count()))
 

--- a/gitensite/apps/bookinfo/management/commands/make_yaml.py
+++ b/gitensite/apps/bookinfo/management/commands/make_yaml.py
@@ -18,13 +18,13 @@ class Command(BaseCommand):
                 book.yaml = pg_rdf_to_yaml(rdffile, repo_name=book.repo_name )
                 book.save()
             except IOError:
-                print "couldn't read " + rdffile
+                print ("couldn't read " + rdffile)
                 continue
             except Exception,e:
-                print "processing " + rdffile
+                print ("processing " + rdffile)
                 raise e
             i+=1
             if count and i>count:
                 break
             if i%100 == 0:
-                print str(i)+" files completed"
+                print (str(i)+" files completed")

--- a/gitensite/apps/bookinfo/management/commands/make_yaml.py
+++ b/gitensite/apps/bookinfo/management/commands/make_yaml.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -*- coding: utf-8 -*-
 
 from django.core.management.base import BaseCommand

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-extensions==1.5.0
 django-el-pagination==2.1.1
 django-secure==1.0.1
 gunicorn==19.2.1
-psycopg2==2.6
+psycopg2==2.7
 Werkzeug==0.10.1
 
 django-zurb-foundation==5.5.0


### PR DESCRIPTION
Note that this will not actually not work in python 3 yet, because the gitberg dependency currently still requires python 2. https://github.com/gitenberg-dev/gitberg/pull/140 should fix this.