### PR TITLE
Uploading covers to S3

### DIFF
--- a/gitensite/apps/bookinfo/db.py
+++ b/gitensite/apps/bookinfo/db.py
@@ -21,14 +21,13 @@ def addBookFromYaml(yaml):
     if "_repo" in obj:
         book.repo_name = obj["_repo"]
         if "covers" in obj:
-            num_existing_covers = len(list(Cover(book=book).objects.all()))
+            num_existing_covers = Cover.objects.filter(book=book).count()
             for cover in obj["covers"]:
                 #Upload cover to S3
-                url = urlparse.urljoin("https://raw.githubusercontent.com/GITenberg/" + obj["_repo"] + "/master/", cover.image_path)
+                url = urlparse.urljoin("https://raw.githubusercontent.com/GITenberg/" + obj["_repo"] + "/master/", cover["image_path"])
                 r = requests.get(url)
                 contentfile = ContentFile(r.content)
-                uploadpath = "/covers/" + obj["_repo"] & ".png"
-                path = default_storage.save(uploadpath, contentfile)
+                uploadpath = obj["_repo"] + ".png"
 
                 #Add cover to database
                 coverobject = Cover.objects.create(

--- a/gitensite/apps/bookinfo/db.py
+++ b/gitensite/apps/bookinfo/db.py
@@ -26,16 +26,17 @@ def addBookFromYaml(yaml):
                 #Upload cover to S3
                 url = urlparse.urljoin("https://raw.githubusercontent.com/GITenberg/" + obj["_repo"] + "/master/", cover["image_path"])
                 r = requests.get(url)
-                contentfile = ContentFile(r.content)
-                uploadpath = obj["_repo"] + ".png"
+                if r.status_code == 200:
+                    contentfile = ContentFile(r.content)
+                    uploadpath = obj["_repo"] + ".png"
 
-                #Add cover to database
-                coverobject = Cover.objects.create(
-                    book=book,
-                    default_cover=(num_existing_covers == 0)
-                )
-                coverobject.file.save(uploadpath, contentfile)
-                coverobject.file.close()
+                    #Add cover to database
+                    coverobject = Cover.objects.create(
+                        book=book,
+                        default_cover=(num_existing_covers == 0)
+                    )
+                    coverobject.file.save(uploadpath, contentfile)
+                    coverobject.file.close()
 
     creator = None
     if "creator" in obj:

--- a/gitensite/apps/bookinfo/migrations/0005_auto_20180501_2256.py
+++ b/gitensite/apps/bookinfo/migrations/0005_auto_20180501_2256.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('bookinfo', '0004_auto_20180228_1951'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='cover',
+            name='link',
+        ),
+        migrations.AddField(
+            model_name='cover',
+            name='file',
+            field=models.FileField(null=True, upload_to=b'bookcovers/', blank=True),
+        ),
+    ]

--- a/gitensite/apps/bookinfo/models.py
+++ b/gitensite/apps/bookinfo/models.py
@@ -98,10 +98,13 @@ class Book(models.Model):
     def cover_url(self):
         existing_covers = list(Cover.objects.filter(book=self))
         for cover in existing_covers:
-            if cover.default_cover:
-                return cover.link
+            if cover.default_cover and cover.file and hasattr(cover.file, "url"):
+                return cover.file.url
+        #No cover is set as default, so return the first cover that has a url
         if len(existing_covers) > 0:
-            return existing_covers[0].link
+            for cover in existing_covers:
+                if cover.file and hasattr(cover.file, "url"):
+                    return cover.file.url
         return None
 
     _pandata=None
@@ -113,7 +116,7 @@ class Book(models.Model):
 
 class Cover(models.Model):
     book = models.ForeignKey(Book, on_delete=models.CASCADE, db_index=True)
-    file = models.FileField(upload_to=path_for_file)
+    file = models.FileField(upload_to="bookcovers/", null=True, blank=True)
     default_cover = models.BooleanField(default=False)
 
 class External_Link(models.Model):

--- a/gitensite/apps/bookinfo/models.py
+++ b/gitensite/apps/bookinfo/models.py
@@ -113,7 +113,7 @@ class Book(models.Model):
 
 class Cover(models.Model):
     book = models.ForeignKey(Book, on_delete=models.CASCADE, db_index=True)
-    link = models.URLField(max_length=500)
+    file = models.FileField(upload_to=path_for_file)
     default_cover = models.BooleanField(default=False)
 
 class External_Link(models.Model):


### PR DESCRIPTION
This PR implements using a FileField to store covers in Amazon S3. When a book is sent to the `/books/post` endpoint, the web server downloads the cover image from the book's Github repo (using the `_repo` and `covers` properties in the YAML), and then uploads it to the S3 bucket in the `bookcovers` directory, storing it in the database in a `FileField`.
Included in this PR is a database migration to create the `FileField`.